### PR TITLE
Rewrite the primitives (Work in progress)

### DIFF
--- a/src/ffi.mjs
+++ b/src/ffi.mjs
@@ -127,12 +127,17 @@ export const text = (content) => content;
 
 /**
  * A workaround for getting custom stateful components to work
+ * XXX broken (issue 13)
  * @param {Element} element
  * @returns {Element}
  */
 export const component = (element) => {
   return createElement(element);
 };
+
+export const create = (fc, props, children) => {
+  return createElement(fc, props, [...children]);
+}
 
 // CONTEXT --------------------------------------------------------------------
 
@@ -169,6 +174,11 @@ export const getContext = (key) => {
 };
 
 export { useContext };
+
+export const provideContext = (getter, value, render) => {
+  const ctx = getter();
+  return createElement(ctx.Provider, {value}, render());
+}
 
 // UTILITY --------------------------------------------------------------------
 

--- a/src/react_gleam.gleam
+++ b/src/react_gleam.gleam
@@ -3,8 +3,8 @@
 // TYPES ----------------------------------------------------------------------
 
 pub external type Element
-pub external type Context(a)
 
+pub external type Context(a)
 
 // GENERAL --------------------------------------------------------------------
 
@@ -16,4 +16,3 @@ pub external fn render(app: Element, root: String) -> Nil =
 // XXX not sure if this is useful
 pub external fn set_context(key: String, value: g) -> Nil =
   "./ffi.mjs" "setContext"
-

--- a/src/react_gleam.gleam
+++ b/src/react_gleam.gleam
@@ -1,10 +1,10 @@
 // IMPORTS --------------------------------------------------------------------
 
-import react_gleam/element.{Element}
-
 // TYPES ----------------------------------------------------------------------
 
-pub external type Context
+pub external type Element
+pub external type Context(a)
+
 
 // GENERAL --------------------------------------------------------------------
 
@@ -13,10 +13,7 @@ pub external fn render(app: Element, root: String) -> Nil =
 
 // CONTEXT --------------------------------------------------------------------
 
+// XXX not sure if this is useful
 pub external fn set_context(key: String, value: g) -> Nil =
   "./ffi.mjs" "setContext"
 
-// COMPONENT ------------------------------------------------------------------
-
-pub external fn component(element: fn() -> Element) -> Element =
-  "./ffi.mjs" "component"

--- a/src/react_gleam/context.gleam
+++ b/src/react_gleam/context.gleam
@@ -1,0 +1,16 @@
+import react_gleam.{Element, Context}
+
+/// To have a typed context, Context(a), we need to have a "source of type" that is used both at
+/// context value providing and consumption.
+/// We can only define the context in JS side, and we can only define an `extern` function, not a variable,
+/// so the only thing we can do is have a `pub external fn get_context_foo () -> Context(Foo) = "someffi.js" "getContextFoo"`
+/// and use such getter in both provider and context hook
+
+pub external fn use_context(Context(a)) -> a = "../ffi.mjs" "useContext"
+
+pub external fn provide_contex(
+  getter: fn () -> Context(a),
+  value: a,
+  render: fn () -> Element
+  ) -> Element = "../ffi.mjs" "provideContext"
+

--- a/src/react_gleam/context.gleam
+++ b/src/react_gleam/context.gleam
@@ -1,16 +1,16 @@
-import react_gleam.{Element, Context}
+import react_gleam.{Context, Element}
 
 /// To have a typed context, Context(a), we need to have a "source of type" that is used both at
 /// context value providing and consumption.
 /// We can only define the context in JS side, and we can only define an `extern` function, not a variable,
 /// so the only thing we can do is have a `pub external fn get_context_foo () -> Context(Foo) = "someffi.js" "getContextFoo"`
 /// and use such getter in both provider and context hook
-
-pub external fn use_context(Context(a)) -> a = "../ffi.mjs" "useContext"
+pub external fn use_context(Context(a)) -> a =
+  "../ffi.mjs" "useContext"
 
 pub external fn provide_contex(
-  getter: fn () -> Context(a),
+  getter: fn() -> Context(a),
   value: a,
-  render: fn () -> Element
-  ) -> Element = "../ffi.mjs" "provideContext"
-
+  render: fn() -> Element,
+) -> Element =
+  "../ffi.mjs" "provideContext"

--- a/src/react_gleam/element.gleam
+++ b/src/react_gleam/element.gleam
@@ -5,12 +5,12 @@
 // IMPORTS --------------------------------------------------------------------
 
 import react_gleam/attribute.{Attribute, attribute}
-
-// TYPES ----------------------------------------------------------------------
-
-pub external type Element
+import react_gleam.{Element}
 
 // CONSTRUCTORS ---------------------------------------------------------------
+pub external fn create(fc: fn (p) -> Element, props : p, children : List(Element)) -> Element =
+  "../ffi.mjs" "create"
+
 
 pub external fn node(
   tag: String,

--- a/src/react_gleam/element.gleam
+++ b/src/react_gleam/element.gleam
@@ -8,9 +8,12 @@ import react_gleam/attribute.{Attribute, attribute}
 import react_gleam.{Element}
 
 // CONSTRUCTORS ---------------------------------------------------------------
-pub external fn create(fc: fn (p) -> Element, props : p, children : List(Element)) -> Element =
+pub external fn create(
+  fc: fn(p) -> Element,
+  props: p,
+  children: List(Element),
+) -> Element =
   "../ffi.mjs" "create"
-
 
 pub external fn node(
   tag: String,

--- a/src/react_gleam/hook.gleam
+++ b/src/react_gleam/hook.gleam
@@ -3,9 +3,8 @@
 import gleam/dynamic.{Dynamic}
 import gleam/option.{Option}
 import react_gleam/dom_element.{DomElement}
-import react_gleam.{Element, Context}
+import react_gleam.{Context, Element}
 import react_gleam/context
-
 
 // TYPES ----------------------------------------------------------------------
 
@@ -20,21 +19,20 @@ pub type Ref(g) {
 pub external fn use_state(initial: fn() -> a) -> #(a, fn(fn(a) -> a) -> Nil) =
   "../ffi.mjs" "useState"
 
-
 /// state api to be used in such syntax:
 /// `use foo, set_foo <- state(initial)`
 ///
 pub fn state(initial, body) -> Element {
-   let #(value, set_value) = use_state(fn () {initial})
-   body(value, set_value)
+  let #(value, set_value) = use_state(fn() { initial })
+  body(value, set_value)
 }
 
 /// state api to be used in such syntax, with lazy initialization value
 /// `use foo, set_foo <- state(fn () { initial })`
 /// the initializer function must by synchronous (not returning a Promise)
 pub fn state_lazy(initial_fun, body) -> Element {
-   let #(value, set_value) = use_state(initial_fun)
-   body(value, set_value)
+  let #(value, set_value) = use_state(initial_fun)
+  body(value, set_value)
 }
 
 // REDUCER --------------------------------------------------------------------
@@ -45,11 +43,7 @@ pub external fn use_reducer(
 ) -> #(a, fn(b) -> Nil) =
   "../ffi.mjs" "useReducer"
 
-pub fn reducer(
-  reducer,
-  initial,
-  body
-  ) -> Element {
+pub fn reducer(reducer, initial, body) -> Element {
   let #(value, set_value) = use_reducer(reducer, initial)
   body(value, set_value)
 }
@@ -104,7 +98,6 @@ pub external fn use_effect7(
 ) -> Nil =
   "../ffi.mjs" "useEffectHook"
 
-
 pub fn effect0(effect_fun, body) -> Element {
   use_effect0(effect_fun)
   body()
@@ -144,6 +137,7 @@ pub fn effect7(effect_fun, deps, body) -> Element {
   use_effect7(effect_fun, deps)
   body()
 }
+
 // MEMO -----------------------------------------------------------------------
 
 pub external fn use_memo1(calculation: fn() -> v, dependencies: #(g)) -> v =
@@ -250,10 +244,7 @@ pub external fn use_context(key: String) -> Result(Dynamic, String) =
   "../ffi.mjs" "useContextHook"
 
 /// use val <- context(val_context_getter)
-pub fn context(
-  getter: fn () -> Context(a),
-  render: fn (a) -> Element
-  ) {
+pub fn context(getter: fn() -> Context(a), render: fn(a) -> Element) {
   let ctx = getter()
   let value = context.use_context(ctx)
   render(value)

--- a/src/react_gleam/hook.gleam
+++ b/src/react_gleam/hook.gleam
@@ -3,6 +3,9 @@
 import gleam/dynamic.{Dynamic}
 import gleam/option.{Option}
 import react_gleam/dom_element.{DomElement}
+import react_gleam.{Element, Context}
+import react_gleam/context
+
 
 // TYPES ----------------------------------------------------------------------
 
@@ -12,8 +15,27 @@ pub type Ref(g) {
 
 // STATE ----------------------------------------------------------------------
 
+/// Direct useState API
+/// returned setState accepts the updater function as parameter, a more generic case
 pub external fn use_state(initial: fn() -> a) -> #(a, fn(fn(a) -> a) -> Nil) =
   "../ffi.mjs" "useState"
+
+
+/// state api to be used in such syntax:
+/// `use foo, set_foo <- state(initial)`
+///
+pub fn state(initial, body) -> Element {
+   let #(value, set_value) = use_state(fn () {initial})
+   body(value, set_value)
+}
+
+/// state api to be used in such syntax, with lazy initialization value
+/// `use foo, set_foo <- state(fn () { initial })`
+/// the initializer function must by synchronous (not returning a Promise)
+pub fn state_lazy(initial_fun, body) -> Element {
+   let #(value, set_value) = use_state(initial_fun)
+   body(value, set_value)
+}
 
 // REDUCER --------------------------------------------------------------------
 
@@ -22,6 +44,15 @@ pub external fn use_reducer(
   initial: a,
 ) -> #(a, fn(b) -> Nil) =
   "../ffi.mjs" "useReducer"
+
+pub fn reducer(
+  reducer,
+  initial,
+  body
+  ) -> Element {
+  let #(value, set_value) = use_reducer(reducer, initial)
+  body(value, set_value)
+}
 
 // EFFECT ---------------------------------------------------------------------
 
@@ -73,6 +104,46 @@ pub external fn use_effect7(
 ) -> Nil =
   "../ffi.mjs" "useEffectHook"
 
+
+pub fn effect0(effect_fun, body) -> Element {
+  use_effect0(effect_fun)
+  body()
+}
+
+pub fn effect1(effect_fun, deps, body) -> Element {
+  use_effect1(effect_fun, deps)
+  body()
+}
+
+pub fn effect2(effect_fun, deps, body) -> Element {
+  use_effect2(effect_fun, deps)
+  body()
+}
+
+pub fn effect3(effect_fun, deps, body) -> Element {
+  use_effect3(effect_fun, deps)
+  body()
+}
+
+pub fn effect4(effect_fun, deps, body) -> Element {
+  use_effect4(effect_fun, deps)
+  body()
+}
+
+pub fn effect5(effect_fun, deps, body) -> Element {
+  use_effect5(effect_fun, deps)
+  body()
+}
+
+pub fn effect6(effect_fun, deps, body) -> Element {
+  use_effect6(effect_fun, deps)
+  body()
+}
+
+pub fn effect7(effect_fun, deps, body) -> Element {
+  use_effect7(effect_fun, deps)
+  body()
+}
 // MEMO -----------------------------------------------------------------------
 
 pub external fn use_memo1(calculation: fn() -> v, dependencies: #(g)) -> v =
@@ -174,5 +245,16 @@ pub external fn use_ref(value: Option(DomElement)) -> Ref(DomElement) =
 
 // CONTEXT --------------------------------------------------------------------
 
+/// XXX I would remove this
 pub external fn use_context(key: String) -> Result(Dynamic, String) =
   "../ffi.mjs" "useContextHook"
+
+/// use val <- context(val_context_getter)
+pub fn context(
+  getter: fn () -> Context(a),
+  render: fn (a) -> Element
+  ) {
+  let ctx = getter()
+  let value = context.use_context(ctx)
+  render(value)
+}

--- a/test/function_component_test.gleam
+++ b/test/function_component_test.gleam
@@ -1,0 +1,38 @@
+import react_gleam.{Element}
+// import react_gleam/attribute.{attribute}
+import react_gleam/hook
+import react_gleam/element
+
+import gleeunit/should
+import gleam/string
+
+external fn render_to_static(element: Element) -> String =
+  "react-dom/server" "renderToStaticMarkup"
+
+type Pet {
+  Pet(name: String)
+}
+
+type PetState {
+  Sitting
+  Running
+}
+
+fn pet_profile(props : Pet) -> Element {
+  use state, _s <- hook.state(Sitting)
+
+  element.div(
+    [],
+    [
+      element.text(
+        "A pet called " <> props.name <> " is " <> string.inspect(state),
+      ),
+    ],
+  )
+}
+
+pub fn first_test() {
+  element.create(pet_profile, Pet(name: "Garfield"), [])
+  |> render_to_static()
+  |> should.equal("<div>A pet called Garfield is Sitting</div>")
+}

--- a/test/function_component_test.gleam
+++ b/test/function_component_test.gleam
@@ -2,7 +2,6 @@ import react_gleam.{Element}
 // import react_gleam/attribute.{attribute}
 import react_gleam/hook
 import react_gleam/element
-
 import gleeunit/should
 import gleam/string
 
@@ -18,7 +17,7 @@ type PetState {
   Running
 }
 
-fn pet_profile(props : Pet) -> Element {
+fn pet_profile(props: Pet) -> Element {
   use state, _s <- hook.state(Sitting)
 
   element.div(


### PR DESCRIPTION
Hi @brettkolodny !

In context of the [unable to maintain state issue](https://github.com/brettkolodny/react-gleam/issues/13) and because I am live-testing `react_gleam` in my personal react-native project, I am trying to make sense of how this package could work in a way that benefits of correctness (coming from types and program structure) and better DX (less verbose, versatile, but concise).

A few observations/thoughts:

1. React's functional components are `(props) => Element` functions. When using JSX, we employ the JSX mechanics that takes tag + its attributes, converts them into a JS object, and then calls this function. In current version of `react_gleam`, we also do this: we convert our Gleam types to Dynamic, so they work with `attribute.Property`, and then in a function component, we receive Dynamic props that we have to decode again. However, the JSX is converted to `React.createElement(function, props, childrem)`, where `props` is an object. So why not just pass a Gleam type, without converting it both ways?.
2. Same goes for externally loaded components (installed from npm) - we could just declare them as eg. `pub external fn muiButton(props: MuiButtonProps) -> Element = "@material-ui/core" "Button"`, and create MuiButtonProps type that matches the props used by library, and use them as follows: `element.create(muiButton, MuiButtonProps(primary: True, color: "#231234"), [element.text("Click me")])`
3. There is a slight problem with optionality of props fields. In gleam components, we can just make sure we always pass all the props as complete type, for external components (which could have 10+ props), we could either pass a type with `Option(a)` types, which gets converted to `a` or `undefined`, or we declare the props to contain a subset of imported props (just ones we use). The last option doesn't make sense for distributing such bindings though. Or perhaps such components should accept a `Dynamic` and that's it. 
4. We would still use `element.node()` kind of component creation for html tags (where the component is no a function but string), and where we pass `List(Attribute)` - it would be hard to create a type for all possible html tags... 
5. The `element.node` could also be used for externally loaded components, if declaring a prop type in advance (point 2) is not good DX. We could have `element.native_node(fn () -> Element, List(Attributes), List(Element))` or similar, where 1st argument is function, not a string.  We could even make it a default and have a function for each tag, eg: `pub fn div () -> Element = "ffi.js" "div"` and then `export const div = (props) => (<div {...props}>{...props.children}</div>);`...
6. As for hooks, it can be really tricky to not fail to break their rules. I run into a problem where React runtime reported i have changed the order of calling them, and I could not figure out where – I figured out that hooks can be called recursively instead one after another,  so we can do: 
   ```
   pub fn counter (_props) => {
      use count, set_count <- state(0)
      use <- effect0(show_tada_emojis)
      ...
   }
   ```
   and this way you can't really skip a call to a hook, because the callback structure orders it..
7. I do not know where to put everywhere used types such as `Element` or `Context`. I've put them in main `react_gleam.gleam` file to avoid import loops; however, `Attribute` is still in `attribute.gleam` because it's not used much elsewhere. Consistency would be useful here, but I am not sure how to achieve it - it also makes sense to put types in relevant domain-submodules.

Check out this PR for proposed changes, and [here is a changed example from the issue](https://github.com/marcinkoziej/gleam_react_bug_report/tree/new_primitives) - which works with these new primitives: